### PR TITLE
Change custom classification of non-MR

### DIFF
--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -583,8 +583,10 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
             classification = classification_from_label.infer_classification(series_desc)
             log.info("Inferred classification from label: %s", classification)
             # GEAR-1084, keep any custom classification already set.
-        if not classification:
-            classification = {'Custom': ['N/A']}
+            if not classification:
+                classification = {'Custom': ['N/A']}
+        elif dcm.get("Modality") != "MR":
+            classification = {}
         dicom_file["classification"] = classification
 
     # If no pixel data present, make classification intent "Non-Image"

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -583,8 +583,8 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
             classification = classification_from_label.infer_classification(series_desc)
             log.info("Inferred classification from label: %s", classification)
             # GEAR-1084, keep any custom classification already set.
-            if not classification:
-                classification = {'Custom': ['N/A']}
+        if not classification:
+            classification = {'Custom': ['N/A']}
         dicom_file["classification"] = classification
 
     # If no pixel data present, make classification intent "Non-Image"


### PR DESCRIPTION
Out-dent the logic following the most recent change to make sure there is some form of custom classification for non-MR images (else gear does the classification, but upload of metadata fails).

- I don't know why this would have been indented to begin with.

- I think the customer technically prefers a blank subclassification after "PT", but I am guessing that "PT:''" will break something internally for us(?).