### PR TITLE
BUG: Set non-image intent to array.

### DIFF
--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -593,7 +593,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
 
     # If no pixel data present, make classification intent "Non-Image"
     if not hasattr(dcm, "PixelData"):
-        nonimage_intent = "Non-Image"
+        nonimage_intent = ["Non-Image"]
         # If classification is a dict, update dict with intent
         if isinstance(dicom_file["classification"], dict):
             classification  = dicom_file['classification']

--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,10 @@
   "source": "https://github.com/flywheel-apps/dicom-mr-classifier/releases",
   "license": "Apache-2.0",
   "flywheel": "0",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "custom": {
     "gear-builder": {
-      "image": "flywheel/dicom-mr-classifier:1.4.6",
+      "image": "flywheel/dicom-mr-classifier:1.4.7",
       "category": "converter"
     },
     "flywheel": {


### PR DESCRIPTION
Classification values must be an array, this version set it as a string which introduced validation errors.