### PR TITLE
ENH: Add dwi regexes to match HCP and ABCD

### DIFF
--- a/classification_from_label.py
+++ b/classification_from_label.py
@@ -114,6 +114,8 @@ def is_anatomy(label):
 # Diffusion
 def is_diffusion(label):
     regexes = [
+        re.compile('^dmri_', re.IGNORECASE),
+        re.compile('_dmri$', re.IGNORECASE),
         re.compile('dti', re.IGNORECASE),
         re.compile('dwi', re.IGNORECASE),
         re.compile('diff_', re.IGNORECASE),


### PR DESCRIPTION
HCP example: dMRI_dir98_AP
ABCD example: ABCD_dMRI

Regexes designed to get both of these but avoid false matches from something like 'boldmri'