### PR TITLE
run_classifier accidentally doesn't set PYTHONPATH

### DIFF
--- a/run_classifier
+++ b/run_classifier
@@ -69,7 +69,7 @@ if [[ -z $@ ]]
         then
             bni=`basename "$input_file"`
             output_file_base=$OUTPUT_DIR/${bni%_dicom.zip}
-            PYHONPATH=$PYTHONPATH:/flywheel/v0/ python $FLYWHEEL_BASE/dicom-mr-classifier.py "$input_file" "$output_file_base" --config-file "$CONFIG_FILE"
+            PYTHONPATH=$PYTHONPATH:/flywheel/v0/ python $FLYWHEEL_BASE/dicom-mr-classifier.py "$input_file" "$output_file_base" --config-file "$CONFIG_FILE"
             E_STATUS=$?
       else
             echo -e "No inputs were provided and $INPUT_DIR has no valid input files!"


### PR DESCRIPTION
Looks like it meant to set PYTHONPATH but it set "PYHONPATH" instead.