### PR TITLE
Classify "MEGRE" as susceptibility

### DIFF
--- a/classification_from_label.py
+++ b/classification_from_label.py
@@ -307,7 +307,8 @@ def is_susceptibility(label):
         re.compile('swi', re.IGNORECASE),
         re.compile('mag_images', re.IGNORECASE),
         re.compile('pha_images', re.IGNORECASE),
-        re.compile('mip_images', re.IGNORECASE)
+        re.compile('mip_images', re.IGNORECASE),
+        re.compile('megre', re.IGNORECASE)
         ]
     return regex_search_label(regexes, label)
 


### PR DESCRIPTION
As per BIDS specification [here](https://bids-specification.readthedocs.io/en/v1.7.0/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data), "`MEGRE`" is used as a suffix for multi-echo gradient echo data, which are utilised for susceptibility-weighted imaging (SWI) and quantitative susceptibility mapping (QSM). We are correspondingly using this acronym in our ReproIn-format `SeriesDescription`s. The MR DICOM classifier however currently assigns "`MR: N/A`" to these acquisitions.

This is a simple proposal to classify "`MEGRE`" as "measurement" -> "susceptibility". I will however use it to suggest that there should be refinement around the classifications here:
- "`MEGRE`" is a classification of raw acquired image data, so is really more "intent" than "measurement".
- Acquisitions labelled as "`swi`" or "`mip_images`" are likely to be *derived* images rather than acquired image data, but are not currently flagged as such.

I however would not want to myself make modifications to such without having at hand exemplar data on which the current logic was based.