### PR TITLE
ENH: Classify vNav setter images as Navigators

### DIFF
--- a/classification_from_label.py
+++ b/classification_from_label.py
@@ -309,6 +309,12 @@ def is_megre(label):
     ]
     return regex_search_label(regexes, label)
 
+# Volumetric navigator
+def is_vnav(label):
+    regexes = [
+        re.compile('_vnav_setter', re.IGNORECASE)
+        ]
+    return regex_search_label(regexes, label)
 
 
 # Utility:  Check a list of regexes for truthyness
@@ -346,6 +352,8 @@ def infer_classification(label):
         elif is_functional(label):
             classification['Intent'] = ['Functional']
             classification['Measurement'] = ['T2*']
+        elif is_vnav(label):
+            classification['Features'] = ['3D', 'EPI', 'Navigator']
         elif is_anatomy_t2(label):
             classification['Intent'] = ['Structural']
             classification['Measurement'] = ['T2']


### PR DESCRIPTION
Hi,

I've not tested this, as I'm not sure how I can test utility gears locally. The idea is to classify volumetric navigator scans as Navigators.

The ABCD project, HCP Lifespan, and others use 3D navigators to prospectively correct motion during T1w and T2w scans. The navigators themselves, the "setter" images, are low-resolution EPI images used to track motion. An example series description might be "ABCD_T1w_MPR_vNav_setter", which consists of multiple low-resolution EPI images. Because of "T1" in the name, these get classified as T1, resulting in many extra NIFTI files and causing problem for gear rules targeting actual T1w images.